### PR TITLE
Refactor useApplicationData.js to useReducer()

### DIFF
--- a/src/components/Application.jsx
+++ b/src/components/Application.jsx
@@ -11,8 +11,7 @@ import {
 import useApplicationData from 'hooks/useApplicationData';
 
 export default function Application() {
-  const { state, setDay, bookInterview, cancelInterview } =
-    useApplicationData();
+  const { state, setDay, editInterview } = useApplicationData();
 
   const dailyInterviewers = getInterviewersForDay(state, state.day);
 
@@ -25,8 +24,7 @@ export default function Application() {
           time={appointment.time}
           interview={getInterview(state, appointment.interview)}
           interviewers={dailyInterviewers}
-          bookInterview={bookInterview}
-          cancelInterview={cancelInterview}
+          editInterview={editInterview}
         />
       );
     }

--- a/src/components/Appointment/index.jsx
+++ b/src/components/Appointment/index.jsx
@@ -34,7 +34,7 @@ export default function Appointment(props) {
     transition(SAVING);
 
     props
-      .bookInterview(props.id, interview)
+      .editInterview(props.id, interview)
       .then(() => transition(SHOW))
       .catch((error) => transition(ERROR_SAVE, true));
   };
@@ -43,7 +43,7 @@ export default function Appointment(props) {
     transition(DELETING, true);
 
     props
-      .cancelInterview(props.id)
+      .editInterview(props.id, null, true)
       .then(() => transition(EMPTY))
       .catch((error) => transition(ERROR_DELETE, true));
   };

--- a/src/hooks/useApplicationData.js
+++ b/src/hooks/useApplicationData.js
@@ -40,7 +40,7 @@ export default function useApplicationData() {
 
   const setDay = (day) => dispatch({ type: 'SET_DAY', day });
 
-  // Get days data from API and set the days state
+  // Get all state data from API and dispatch to reducer
   useEffect(() => {
     Promise.all([
       axios.get('http://localhost:8001/api/days'),
@@ -72,12 +72,12 @@ export default function useApplicationData() {
     const days = [...state.days];
     days[currentDayIndex] = { ...currentDay, spots };
 
-    return days;
+    dispatch({ type: 'SET_INTERVIEW', appointments, days });
   };
 
   // Book, edit or cancel an interview.
-  const editInterview = async (id, interviewInfo, cancel = false) => {
-    const interview = cancel ? null : { ...interviewInfo };
+  const editInterview = async (id, interviewData, cancel = false) => {
+    const interview = cancel ? null : { ...interviewData };
 
     const appointment = {
       ...state.appointments[id],
@@ -99,8 +99,8 @@ export default function useApplicationData() {
       );
     }
 
-    const days = updateSpots(state, appointments, id);
-    dispatch({ type: 'SET_INTERVIEW', id, appointments, days });
+    // Update spots remaining and pass info to be dispatched
+    updateSpots(state, appointments);
   };
 
   return { state, setDay, editInterview };


### PR DESCRIPTION
Changes the `useApplicationData` hook to rely on `useReducer()` instead of `useState()`. 

Also refactored the `bookInterview()` and `cancelnterview()` into a single `editInterview()` function.